### PR TITLE
Xgu misc fixes

### DIFF
--- a/lib/xgu/xgux.h
+++ b/lib/xgu/xgux.h
@@ -431,6 +431,7 @@ static const float nv10_spot_params[2][16] = {
 	  3.10, 3.16, 3.23, 3.27, 3.37, 3.47, 3.83, 5.11 },
 };
 
+static
 void
 nv10_get_spot_coeff(float SpotExponent, float SpotCutoff, XguVec3 _NormSpotDirection, float k[7])
 {

--- a/lib/xgu/xgux.h
+++ b/lib/xgu/xgux.h
@@ -95,7 +95,7 @@ XGUX_API
 void xgux_set_attrib_pointer(XguVertexArray index, XguVertexArrayType format, unsigned int size, unsigned int stride, const void* data) {
     uint32_t *p = pb_begin();
     p = xgu_set_vertex_data_array_format(p, index, format, size, stride);
-    p = xgu_set_vertex_data_array_offset(p, index, (uint32_t)data & 0x03ffffff);
+    p = xgu_set_vertex_data_array_offset(p, index, (void*)((uint32_t)data & 0x03ffffff));
     pb_end(p);
 }
 
@@ -204,7 +204,7 @@ uint32_t* xgux_set_color4ub(uint32_t* p, uint8_t r, uint8_t g, uint8_t b, uint8_
 
 XGUX_API
 uint32_t* xgux_set_texcoord3f(uint32_t* p, unsigned int index, float s, float t, float r) {
-    return xgu_set_vertex_data4f(p, 9+index, s, t, r, 1.0f);
+    return xgu_set_vertex_data4f(p, (XguVertexArray)(9+index), s, t, r, 1.0f);
 }
 
 


### PR DESCRIPTION
Lack of type casting in some places was causing C++ compilation to fail. Casting in said places has been added.
Also, `nv10_get_spot_coeff()` not being static was causing a duplicate symbol error.